### PR TITLE
fix: JRPSの「無料」表記の誤解を防ぐ修正（patient_guide.html）

### DIFF
--- a/docs/public/patient_guide.html
+++ b/docs/public/patient_guide.html
@@ -245,13 +245,13 @@
                 
                 <div class="action-item">
                     <h3>2. 🏥 臨床試験情報をフォローする</h3>
-                    <p><strong>なぜ重要か：</strong>承認前に治療を受けられる唯一の方法。費用も無料。</p>
-                    
+                    <p><strong>なぜ重要か：</strong>承認前に治療を受けられる唯一の方法。臨床試験の参加費用は無料。</p>
+
                     <h4>チェックすべきサイト（3ヶ月に1回）：</h4>
                     <ul>
                         <li><a href="https://clinicaltrials.gov" target="_blank">ClinicalTrials.gov</a>（英語）- 検索：「retinitis pigmentosa Japan」</li>
                         <li><a href="https://jrct.niph.go.jp" target="_blank">jRCT</a>（日本語）- 検索：「網膜色素変性」</li>
-                        <li><a href="https://www.jrps.org" target="_blank">日本網膜色素変性症協会（JRPS）</a> - 最新情報をメルマガで配信</li>
+                        <li><a href="https://www.jrps.org" target="_blank">日本網膜色素変性症協会（JRPS）</a>（年会費5,000円） - 最新情報をメルマガで配信</li>
                     </ul>
                     
                     <h4>企業の治験情報ページ：</h4>


### PR DESCRIPTION
## 📋 問題の概要

`docs/public/patient_guide.html`の臨床試験セクションで、「費用も無料」という記載の直後に「日本網膜色素変性症協会（JRPS）」が記載されており、JRPSが無料と誤解される可能性がありました。

患者・ご家族からのフィードバックで、JRPSは年会費5,000円がかかるにも関わらず、無料と誤解される可能性があるとの指摘を受けました。

## 🎯 修正内容

### 修正対象ファイル
- `docs/public/patient_guide.html`

### 変更内容

**修正前（248行目）:**
```html
<p><strong>なぜ重要か：</strong>承認前に治療を受けられる唯一の方法。費用も無料。</p>
```

**修正後:**
```html
<p><strong>なぜ重要か：</strong>承認前に治療を受けられる唯一の方法。臨床試験の参加費用は無料。</p>
```

**修正前（254行目）:**
```html
<li><a href="https://www.jrps.org" target="_blank">日本網膜色素変性症協会（JRPS）</a> - 最新情報をメルマガで配信</li>
```

**修正後:**
```html
<li><a href="https://www.jrps.org" target="_blank">日本網膜色素変性症協会（JRPS）</a>（年会費5,000円） - 最新情報をメルマガで配信</li>
```

## 📌 優先度

**高**: 患者・ご家族の誤解を防ぐため、早急な修正が必要

## 🔗 関連情報

Closes #33

患者・ご家族からのLINEフィードバックに基づく改善