### PR TITLE
docs: 開発ワークフローにPRポリシーを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,11 +117,35 @@ python scripts/update_latest_info.py
 
 ## 開発ワークフロー
 
-1. すべての変更は`develop`ブランチで作業
-2. 実装順序はTASK_LIST.jsonのタスクリストに従う
-3. すべてのデータ変換をコード化（手動ステップなし）
-4. 外部依存関係やAPIキーが必要な場合は文書化
-5. 変更をコミットする前にテストを実行
+**重要: すべての変更は必ずPull Request（PR）を通して適用すること**
+
+1. **ブランチ戦略**:
+   - `develop`ブランチに直接コミット・プッシュしない
+   - 機能追加・修正は必ず新しいブランチを作成: `feature/xxx`, `fix/xxx`, `docs/xxx`
+   - 変更完了後はPRを作成し、レビュー後に`develop`にマージ
+
+2. **PR作成の手順**:
+   ```bash
+   # 1. developブランチから最新を取得
+   git checkout develop && git pull
+
+   # 2. 新しいブランチを作成
+   git checkout -b fix/issue-number-description
+
+   # 3. 変更を実装・コミット
+   git add . && git commit -m "fix: description"
+
+   # 4. リモートにプッシュ
+   git push -u origin fix/issue-number-description
+
+   # 5. PRを作成
+   gh pr create --base develop --title "fix: description" --body "..."
+   ```
+
+3. 実装順序はTASK_LIST.jsonのタスクリストに従う
+4. すべてのデータ変換をコード化（手動ステップなし）
+5. 外部依存関係やAPIキーが必要な場合は文書化
+6. 変更をコミットする前にテストを実行
 
 ## 重要なファイル
 


### PR DESCRIPTION
## 📋 変更概要

CLAUDE.mdの開発ワークフローセクションに、すべての変更は必ずPull Request（PR）を通して適用する旨を明記しました。

## 🎯 変更内容

### 追加した内容

1. **重要な注意事項**:
   - すべての変更は必ずPRを通して適用すること

2. **ブランチ戦略**:
   - `develop`ブランチに直接コミット・プッシュしない
   - 機能追加・修正は必ず新しいブランチを作成: `feature/xxx`, `fix/xxx`, `docs/xxx`
   - 変更完了後はPRを作成し、レビュー後に`develop`にマージ

3. **PR作成の手順** (コマンド例付き):
   ```bash
   # 1. developブランチから最新を取得
   git checkout develop && git pull

   # 2. 新しいブランチを作成
   git checkout -b fix/issue-number-description

   # 3. 変更を実装・コミット
   git add . && git commit -m "fix: description"

   # 4. リモートにプッシュ
   git push -u origin fix/issue-number-description

   # 5. PRを作成
   gh pr create --base develop --title "fix: description" --body "..."
   ```

## 📌 背景

developブランチへの直接コミットを防ぎ、コードレビューとCI/CDチェックを通過した変更のみをマージするため、開発プロセスを明文化しました。

## ✅ メリット

- コード品質の向上（レビュープロセス）
- CI/CDチェックの確実な実行
- 変更履歴の追跡が容易
- 問題発生時のロールバックが簡単