### PR TITLE
feat: 患者ガイドにネクストビジョンを情報源として追加

### DIFF
--- a/docs/public/patient_guide.html
+++ b/docs/public/patient_guide.html
@@ -398,7 +398,8 @@
                 
                 <h3>患者支援</h3>
                 <ul>
-                    <li><a href="https://www.jrps.org/" target="_blank">日本網膜色素変性症協会（JRPS）</a></li>
+                    <li><a href="https://www.jrps.org/" target="_blank">日本網膜色素変性症協会（JRPS）</a> - 年会費5,000円で治験情報、医療講演会、患者交流会に参加可能</li>
+                    <li><a href="https://nextvision.or.jp" target="_blank">ネクストビジョン</a> - 視覚障害・眼科関連のイベント、啓発活動、最新研究動向（無料）</li>
                     <li><a href="https://www.nanbyou.or.jp/" target="_blank">難病情報センター</a></li>
                     <li><a href="tel:0120279338">遺伝カウンセリング相談（いでんネット）</a></li>
                 </ul>


### PR DESCRIPTION
## 📋 問題の概要

患者・ご家族向けページ（`patient_guide.html`）に、視覚障害や眼科関連のイベント・啓発活動を行っているネクストビジョン（https://nextvision.or.jp）の情報が含まれていませんでした。

患者・ご家族からのフィードバックで、有益なリソースとして追加の要望がありました。

## 🎯 追加内容

### 修正対象ファイル
- `docs/public/patient_guide.html`

### 追加場所
「役立つリンク集」セクションの「患者支援」部分（401-402行目）

### 追加した内容

**修正前:**
```html
<li><a href="https://www.jrps.org/" target="_blank">日本網膜色素変性症協会（JRPS）</a></li>
```

**修正後:**
```html
<li><a href="https://www.jrps.org/" target="_blank">日本網膜色素変性症協会（JRPS）</a> - 年会費5,000円で治験情報、医療講演会、患者交流会に参加可能</li>
<li><a href="https://nextvision.or.jp" target="_blank">ネクストビジョン</a> - 視覚障害・眼科関連のイベント、啓発活動、最新研究動向（無料）</li>
```

### 変更内容

1. **ネクストビジョンを追加**:
   - URL: https://nextvision.or.jp
   - 説明: 視覚障害・眼科関連のイベント、啓発活動、最新研究動向（無料）

2. **JRPSの情報を拡充**:
   - 年会費5,000円の情報を追加
   - 提供される情報（治験情報、医療講演会、患者交流会）を明記

## ✅ チェック済み

- [x] `patient_guide.html`にネクストビジョンを追加
- [x] リンクがクリッカブルになっているか確認
- [x] JRPSの情報も拡充（誤解防止）
- [x] コミット & プッシュ

## 📌 優先度

**高**: 患者・ご家族にとって有益な情報源のため、早めの追加が望ましい

## 🔗 関連情報

Closes #34

- ネクストビジョン: https://nextvision.or.jp
- 患者・ご家族からのLINEフィードバックに基づく改善