### PR TITLE
fix: CI/CDでbuild_report.pyのPYTHONPATH設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     
     - name: Generate report
       run: |
-        python src/reporting/build_report.py
+        PYTHONPATH=. python src/reporting/build_report.py
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- CI/CDパイプラインで`build_report.py`実行時に`ModuleNotFoundError: No module named 'src'`が発生する問題を修正
- `PYTHONPATH=.`を設定して`src.reporting`モジュールの参照を解決

## Test plan
- [x] `act --list`でYAML構文チェック通過
- [ ] CI/CDパイプラインが正常完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)